### PR TITLE
Update 28-fringe.scm

### DIFF
--- a/chp2/code/28-fringe.scm
+++ b/chp2/code/28-fringe.scm
@@ -7,4 +7,4 @@
             (list tree))
           (else
             (append (fringe (car tree))         ; 累积左子树所有元素
-                    (fringe (cadr tree))))))    ; 累积右子树所有元素
+                    (fringe (cdr tree))))))     ; 累积右子树所有元素


### PR DESCRIPTION
fixed a bug where right tree should be "(cdr tree)" rather than "(cadr tree)"
